### PR TITLE
Fix code scanning alert no. 1: Missing regular expression anchor

### DIFF
--- a/scanner/signatures/pattern.go
+++ b/scanner/signatures/pattern.go
@@ -470,7 +470,7 @@ var PatternSignatures = []Signature{
 	},
 	PatternSignature{
 		part:        PartContent,
-		match:       regexp.MustCompile(`(https\\://outlook\\.office.com/webhook/[0-9a-f-]{36}\\@)`),
+		match:       regexp.MustCompile(`^(https\\://outlook\\.office.com/webhook/[0-9a-f-]{36}\\@)$`),
 		description: "Outlook Team",
 		comment:     "",
 	},


### PR DESCRIPTION
Fixes [https://github.com/grmvarma/secret-scanner/security/code-scanning/1](https://github.com/grmvarma/secret-scanner/security/code-scanning/1)

To fix the problem, we need to add anchors to the regular expression to ensure it matches the pattern only at the beginning and end of the string. This can be done by adding `^` at the beginning and `$` at the end of the regular expression.

- Add `^` at the beginning of the regular expression to anchor it to the start of the string.
- Add `$` at the end of the regular expression to anchor it to the end of the string.
- Update the regular expression in the file `scanner/signatures/pattern.go` on line 473.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
