### PR TITLE
Fix code scanning alert no. 6: Incomplete regular expression for hostnames

### DIFF
--- a/scanner/signatures/pattern.go
+++ b/scanner/signatures/pattern.go
@@ -470,7 +470,7 @@ var PatternSignatures = []Signature{
 	},
 	PatternSignature{
 		part:        PartContent,
-		match:       regexp.MustCompile(`^(https\\://outlook\\.office.com/webhook/[0-9a-f-]{36}\\@)$`),
+		match:       regexp.MustCompile(`^(https\\://outlook\\.office\\.com/webhook/[0-9a-f-]{36}\\@)$`),
 		description: "Outlook Team",
 		comment:     "",
 	},


### PR DESCRIPTION
Fixes [https://github.com/grmvarma/secret-scanner/security/code-scanning/6](https://github.com/grmvarma/secret-scanner/security/code-scanning/6)

To fix the problem, we need to escape the dot before 'com' in the regular expression. This ensures that the dot is treated as a literal character rather than a wildcard, thus preventing unintended matches. The best way to fix this without changing existing functionality is to modify the regular expression to escape the dot properly.

- Locate the regular expression on line 473 in the file `scanner/signatures/pattern.go`.
- Update the regular expression to escape the dot before 'com'.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
