### PR TITLE
Fix code scanning alert no. 2: Missing regular expression anchor

### DIFF
--- a/scanner/signatures/pattern.go
+++ b/scanner/signatures/pattern.go
@@ -494,7 +494,7 @@ var PatternSignatures = []Signature{
 	//},
 	PatternSignature{
 		part:        PartContent,
-		match:       regexp.MustCompile(`https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}`),
+		match:       regexp.MustCompile(`^https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}$`),
 		description: "Slack Webhook",
 		comment:     "",
 	},


### PR DESCRIPTION
Fixes [https://github.com/grmvarma/secret-scanner/security/code-scanning/2](https://github.com/grmvarma/secret-scanner/security/code-scanning/2)

To fix the problem, we need to add anchors to the regular expression to ensure it matches the entire string and not just a part of it. Specifically, we should add the `^` anchor at the beginning and the `$` anchor at the end of the regular expression. This change will ensure that the regular expression matches only if the entire string conforms to the pattern.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
