### PR TITLE
Fix code scanning alert no. 5: Incomplete regular expression for hostnames

### DIFF
--- a/scanner/signatures/pattern.go
+++ b/scanner/signatures/pattern.go
@@ -494,7 +494,7 @@ var PatternSignatures = []Signature{
 	//},
 	PatternSignature{
 		part:        PartContent,
-		match:       regexp.MustCompile(`^https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}$`),
+		match:       regexp.MustCompile(`^https://hooks\\.slack\\.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}$`),
 		description: "Slack Webhook",
 		comment:     "",
 	},


### PR DESCRIPTION
Fixes [https://github.com/grmvarma/secret-scanner/security/code-scanning/5](https://github.com/grmvarma/secret-scanner/security/code-scanning/5)

To fix the problem, we need to escape the dot in the regular expression to ensure it matches only the literal dot character and not any character. This can be done by replacing the dot with `\\.` in the regular expression. This change will ensure that the regular expression matches only URLs from the intended host.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
